### PR TITLE
fix: optimize date comparison logic in message time pipe

### DIFF
--- a/frontend/src/app/pipes/message-time.pipe.ts
+++ b/frontend/src/app/pipes/message-time.pipe.ts
@@ -11,7 +11,9 @@ export class MessageTimePipe implements PipeTransform {
 
   transform(value: any | string, ...args: unknown[]): any {
     let m = moment(value);
-    let daysDiff = m.diff(moment(), 'days');
+    const today = moment().startOf('day');
+    const messageDay = m.clone().startOf('day');
+    const daysDiff = messageDay.diff(today, 'days');
     switch (true) {
       case daysDiff > 0: // Future
         return m.calendar();


### PR DESCRIPTION
This pull request updates the `MessageTimePipe` to improve the calculation of the difference in days between a message timestamp and the current date. The change ensures that the comparison is based on the start of the day, providing more accurate results.

### Improvements to date difference calculation:

* [`frontend/src/app/pipes/message-time.pipe.ts`](diffhunk://#diff-9a882b2895bde3383d2a42725405b8250716eb51562627d229a5602d0c9e41cfL14-R16): Updated the `transform` method to calculate the difference in days using the start of the day for both the current date and the message date. This change replaces the previous implementation, which could lead to inaccuracies when comparing timestamps.